### PR TITLE
feat: make VanaWidget environment-aware and library-ready

### DIFF
--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -1,8 +1,9 @@
-import { useNavigate } from 'react-router-dom';
-import { LinkedinIcon, Eye, Stars, Sparkles } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
-import VanaWidget from './VanaWidget';
-import JSON5 from 'json5';
+import { useNavigate } from "react-router-dom";
+import { LinkedinIcon, Eye, Stars, Sparkles } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import VanaWidget from "./VanaWidget";
+import JSON5 from "json5";
+import { useMemo } from "react";
 
 // Define a type for the LinkedIn data
 interface Position {
@@ -91,26 +92,44 @@ const Landing = ({ onDataConnect }: LandingProps) => {
   const navigate = useNavigate();
   const { toast } = useToast();
 
+  // Determine Vana environment configuration
+  const vanaConfig = useMemo(() => {
+    const host = typeof window !== "undefined" ? window.location.hostname : "";
+    const isDev =
+      host.startsWith("dev.") ||
+      host.includes("localhost") ||
+      host.includes("vercel.app");
+
+    return isDev
+      ? { origin: "https://dev.app.vana.com", schemaId: 24 }
+      : { origin: "https://app.vana.com" };
+  }, []);
+
   const parseJsonWithJSON5 = (data: string): LinkedInData | null => {
     try {
-      let cleaned = data.replace(/```(json)?\s*/gi, '').replace(/```/g, '');
+      let cleaned = data.replace(/```(json)?\s*/gi, "").replace(/```/g, "");
       if (cleaned.startsWith('"') && cleaned.endsWith('"')) {
         cleaned = cleaned.slice(1, -1);
       }
-      cleaned = cleaned.replace(/\\"/g, '"').replace(/\\n/g, '\n');
+      cleaned = cleaned.replace(/\\"/g, '"').replace(/\\n/g, "\n");
       return JSON5.parse(cleaned);
     } catch (err) {
-      console.error("Invalid JSON after cleaning:", err, "\nCleaned string was:\n", data);
+      console.error(
+        "Invalid JSON after cleaning:",
+        err,
+        "\nCleaned string was:\n",
+        data
+      );
       return null;
     }
-  }
+  };
 
   const handleVanaResult = (data: unknown) => {
     try {
       let parsedData: LinkedInData | null = null;
-      if (typeof data === 'object' && data !== null) {
+      if (typeof data === "object" && data !== null) {
         parsedData = data as LinkedInData;
-      } else if (typeof data === 'string') {
+      } else if (typeof data === "string") {
         parsedData = parseJsonWithJSON5(data);
       }
 
@@ -120,12 +139,12 @@ const Landing = ({ onDataConnect }: LandingProps) => {
           title: "Connected Successfully!",
           description: "Your professional journey awaits divination...",
         });
-        navigate('/reading');
+        navigate("/reading");
       } else {
         throw new Error("Failed to parse LinkedIn data from Vana widget.");
       }
     } catch (error) {
-      console.error('Error processing Vana result:', error);
+      console.error("Error processing Vana result:", error);
       toast({
         title: "Connection Failed",
         description: "Could not process your LinkedIn data. Please try again.",
@@ -222,17 +241,20 @@ const Landing = ({ onDataConnect }: LandingProps) => {
                     <LinkedinIcon className="w-10 h-10 text-primary" />
                   </div>
                 </div>
-                
+
                 <div className="space-y-4">
                   <h3 className="font-amatic text-3xl font-bold text-foreground tracking-wide">
                     CONNECT YOUR PROFESSIONAL ESSENCE
                   </h3>
                   <p className="font-cormorant text-muted-foreground max-w-md mx-auto italic text-lg">
-                    Channel the mystical energy of your LinkedIn profile to reveal hidden career insights
+                    Channel the mystical energy of your LinkedIn profile to
+                    reveal hidden career insights
                   </p>
                 </div>
 
                 <VanaWidget
+                  appId="com.lovable.tarot-oracle"
+                  onResult={handleVanaResult}
                   onError={(error) => {
                     console.error("Vana Widget Error:", error);
                     toast({
@@ -241,11 +263,14 @@ const Landing = ({ onDataConnect }: LandingProps) => {
                       variant: "destructive",
                     });
                   }}
-                  onAuth={(wallet) => console.log("User authenticated:", wallet)}
-                  onResult={handleVanaResult}
+                  onAuth={(wallet) =>
+                    console.log("User authenticated:", wallet)
+                  }
+                  iframeOrigin={vanaConfig.origin}
+                  {...(vanaConfig.schemaId && {
+                    schemaId: vanaConfig.schemaId,
+                  })}
                   prompt={vanaPrompt}
-                  appId="com.lovable.tarot-oracle"
-                  schemaId={24}
                 />
               </div>
             </div>
@@ -267,7 +292,7 @@ const Landing = ({ onDataConnect }: LandingProps) => {
                   <div className="w-1 h-1 bg-mystic-gold rounded-full" />
                 </div>
               </div>
-              
+
               <h4 className="font-amatic text-2xl font-bold text-mystic-gold mb-4 flex items-center justify-center gap-2 tracking-wide">
                 <Eye className="w-6 h-6" />
                 RITUAL OF PROFESSIONAL DIVINATION
@@ -275,16 +300,28 @@ const Landing = ({ onDataConnect }: LandingProps) => {
               </h4>
               <ol className="text-left space-y-4 text-foreground/80 font-cormorant text-lg">
                 <li className="flex items-start gap-4">
-                  <span className="text-primary font-bold text-2xl font-amatic">I.</span>
-                  <span className="italic">Grant access to your LinkedIn professional aura</span>
+                  <span className="text-primary font-bold text-2xl font-amatic">
+                    I.
+                  </span>
+                  <span className="italic">
+                    Grant access to your LinkedIn professional aura
+                  </span>
                 </li>
                 <li className="flex items-start gap-4">
-                  <span className="text-accent font-bold text-2xl font-amatic">II.</span>
-                  <span className="italic">Allow the oracle to channel your career essence</span>
+                  <span className="text-accent font-bold text-2xl font-amatic">
+                    II.
+                  </span>
+                  <span className="italic">
+                    Allow the oracle to channel your career essence
+                  </span>
                 </li>
                 <li className="flex items-start gap-4">
-                  <span className="text-secondary font-bold text-2xl font-amatic">III.</span>
-                  <span className="italic">Witness the mystical revelation of your professional destiny</span>
+                  <span className="text-secondary font-bold text-2xl font-amatic">
+                    III.
+                  </span>
+                  <span className="italic">
+                    Witness the mystical revelation of your professional destiny
+                  </span>
                 </li>
               </ol>
             </div>

--- a/src/components/VanaWidget.tsx
+++ b/src/components/VanaWidget.tsx
@@ -2,32 +2,32 @@
 
 import { useEffect, useRef } from "react";
 
-const IFRAME_ORIGIN = "https://vana-vibes-web.vercel.app";
-const IFRAME_SRC = `${IFRAME_ORIGIN}/embed/upload`;
-
 interface VanaWidgetProps {
+  appId: string;
   onResult: (data: string) => void;
   onError: (error: string) => void;
   onAuth: (walletAddress: string) => void;
-  prompt?: string;
-  appId: string;
+  iframeOrigin?: string;
   schemaId?: number;
+  prompt?: string;
 }
 
 const VanaWidget = ({
+  appId,
   onResult,
   onError,
   onAuth,
-  prompt,
-  appId,
+  iframeOrigin = "https://app.vana.com",
   schemaId,
+  prompt,
 }: VanaWidgetProps) => {
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const iframeSrc = `${iframeOrigin}/embed/upload`;
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       // Validate origin for security
-      if (event.origin !== IFRAME_ORIGIN) {
+      if (event.origin !== iframeOrigin) {
         return;
       }
 
@@ -45,7 +45,7 @@ const VanaWidget = ({
                 aiPrompt: prompt,
                 embeddingOrigin: window.location.origin,
               },
-              IFRAME_ORIGIN
+              iframeOrigin
             );
           }
           break;
@@ -59,7 +59,7 @@ const VanaWidget = ({
               {
                 ...event.data?.data,
               },
-              IFRAME_ORIGIN
+              iframeOrigin
             );
           }
           break;
@@ -100,13 +100,13 @@ const VanaWidget = ({
     return () => {
       window.removeEventListener("message", handleMessage);
     };
-  }, [onResult, onError, onAuth, prompt, appId, schemaId]);
+  }, [onResult, onError, onAuth, prompt, appId, schemaId, iframeOrigin]);
 
   return (
     <div className="w-full relative">
       <iframe
         ref={iframeRef}
-        src={IFRAME_SRC}
+        src={iframeSrc}
         className="w-full border-none"
         sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox"
       />


### PR DESCRIPTION
## Summary
- Made VanaWidget dynamically adapt to deployment environment
- Widget automatically detects prod vs dev based on URL pattern
- Prepared VanaWidget to be extractable as a standalone library

## Changes
- **VanaWidget component**:
  - Removed hardcoded iframe origin
  - Made schemaId optional
  - Added iframeOrigin prop with sensible default
  - Reordered props for better organization (required first, callbacks grouped, optional last)

- **Landing component**:
  - Added environment detection logic based on hostname
  - Dev environment: URLs starting with `dev.`, localhost, or vercel.app use dev.app.vana.com with schemaId 24
  - Prod environment: All other URLs use app.vana.com without schemaId
  - Props are conditionally spread to avoid passing undefined values

## Test plan
- [ ] Test on localhost - should use dev.app.vana.com with schemaId 24
- [ ] Test on dev.<domain>.com - should use dev.app.vana.com with schemaId 24
- [ ] Test on <domain>.com - should use app.vana.com without schemaId
- [ ] Verify widget loads and authenticates correctly in both environments

🤖 Generated with [Claude Code](https://claude.ai/code)